### PR TITLE
Support PackedCoordinateSequence in MvtReader

### DIFF
--- a/src/main/java/com/wdtinc/mapbox_vector_tile/adapt/jts/JtsAdapter.java
+++ b/src/main/java/com/wdtinc/mapbox_vector_tile/adapt/jts/JtsAdapter.java
@@ -1,6 +1,6 @@
 package com.wdtinc.mapbox_vector_tile.adapt.jts;
 
-import org.locationtech.jts.algorithm.CGAlgorithms;
+import org.locationtech.jts.algorithm.Area;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.geom.util.AffineTransformation;
 import org.locationtech.jts.simplify.TopologyPreservingSimplifier;
@@ -357,7 +357,7 @@ public final class JtsAdapter {
                 final LineString exteriorRing = nextPoly.getExteriorRing();
 
                 // Area must be non-zero
-                final double exteriorArea = CGAlgorithms.signedArea(exteriorRing.getCoordinates());
+                final double exteriorArea = Area.ofRingSigned(exteriorRing.getCoordinates());
                 if(((int) Math.round(exteriorArea)) == 0) {
                     continue;
                 }
@@ -376,7 +376,7 @@ public final class JtsAdapter {
                     final LineString nextInteriorRing = nextPoly.getInteriorRingN(ringIndex);
 
                     // Area must be non-zero
-                    final double interiorArea = CGAlgorithms.signedArea(nextInteriorRing.getCoordinates());
+                    final double interiorArea = Area.ofRingSigned(nextInteriorRing.getCoordinates());
                     if(((int)Math.round(interiorArea)) == 0) {
                         continue;
                     }

--- a/src/main/java/com/wdtinc/mapbox_vector_tile/adapt/jts/MvtReader.java
+++ b/src/main/java/com/wdtinc/mapbox_vector_tile/adapt/jts/MvtReader.java
@@ -1,6 +1,6 @@
 package com.wdtinc.mapbox_vector_tile.adapt.jts;
 
-import org.locationtech.jts.algorithm.CGAlgorithms;
+import org.locationtech.jts.algorithm.Area;
 import org.locationtech.jts.geom.*;
 import com.wdtinc.mapbox_vector_tile.adapt.jts.model.JtsLayer;
 import com.wdtinc.mapbox_vector_tile.adapt.jts.model.JtsMvt;
@@ -494,7 +494,7 @@ public final class MvtReader {
             LinearRing outerPoly = null;
 
             for(LinearRing r : rings) {
-                double area = CGAlgorithms.signedArea(r.getCoordinates());
+                double area = Area.ofRingSigned(r.getCoordinates());
 
                 if(!r.isRing()) {
                     continue; // sanity check, could probably be handled in a isSimple() check
@@ -550,7 +550,7 @@ public final class MvtReader {
             LinearRing outerPoly = null;
 
             for(LinearRing r : rings) {
-                double area = CGAlgorithms.signedArea(r.getCoordinates());
+                double area = Area.ofRingSigned(r.getCoordinates());
 
                 if(!r.isRing()) {
                     continue; // sanity check, could probably be handled in a isSimple() check

--- a/src/main/java/com/wdtinc/mapbox_vector_tile/adapt/jts/MvtReader.java
+++ b/src/main/java/com/wdtinc/mapbox_vector_tile/adapt/jts/MvtReader.java
@@ -217,7 +217,6 @@ public final class MvtReader {
 
         final CoordinateSequence coordSeq = geomFactory.getCoordinateSequenceFactory().create(cmdLength, 2);
         int coordIndex = 0;
-        Coordinate nextCoord;
 
         while(i < geomCmds.size() - 1) {
             cursor.add(
@@ -225,9 +224,9 @@ public final class MvtReader {
                     ZigZag.decode(geomCmds.get(i++))
             );
 
-            nextCoord = coordSeq.getCoordinate(coordIndex++);
-            nextCoord.setOrdinate(0, cursor.x);
-            nextCoord.setOrdinate(1, cursor.y);
+            coordSeq.setOrdinate(coordIndex, 0, cursor.x);
+            coordSeq.setOrdinate(coordIndex, 1, cursor.y);
+            coordIndex++;
         }
 
         return coordSeq.size() == 1 ? geomFactory.createPoint(coordSeq) : geomFactory.createMultiPoint(coordSeq);
@@ -256,7 +255,6 @@ public final class MvtReader {
         GeomCmd cmd;
         List<LineString> geoms = new ArrayList<>(1);
         CoordinateSequence nextCoordSeq;
-        Coordinate nextCoord;
 
         while(i <= geomCmds.size() - MIN_LINE_STRING_LEN) {
 
@@ -304,9 +302,8 @@ public final class MvtReader {
             nextCoordSeq = geomFactory.getCoordinateSequenceFactory().create(1 + cmdLength, 2);
 
             // Set first point from MoveTo command
-            nextCoord = nextCoordSeq.getCoordinate(0);
-            nextCoord.setOrdinate(0, cursor.x);
-            nextCoord.setOrdinate(1, cursor.y);
+            nextCoordSeq.setOrdinate(0, 0, cursor.x);
+            nextCoordSeq.setOrdinate(0, 1, cursor.y);
 
             // Set remaining points from LineTo command
             for(int lineToIndex = 0; lineToIndex < cmdLength; ++lineToIndex) {
@@ -317,9 +314,8 @@ public final class MvtReader {
                         ZigZag.decode(geomCmds.get(i++))
                 );
 
-                nextCoord = nextCoordSeq.getCoordinate(lineToIndex + 1);
-                nextCoord.setOrdinate(0, cursor.x);
-                nextCoord.setOrdinate(1, cursor.y);
+                nextCoordSeq.setOrdinate(lineToIndex + 1, 0, cursor.x);
+                nextCoordSeq.setOrdinate(lineToIndex + 1, 1, cursor.y);
             }
 
             geoms.add(geomFactory.createLineString(nextCoordSeq));
@@ -355,7 +351,6 @@ public final class MvtReader {
         GeomCmd cmd;
         List<LinearRing> rings = new ArrayList<>(1);
         CoordinateSequence nextCoordSeq;
-        Coordinate nextCoord;
 
         while(i <= geomCmds.size() - MIN_POLYGON_LEN) {
 
@@ -403,9 +398,8 @@ public final class MvtReader {
             nextCoordSeq = geomFactory.getCoordinateSequenceFactory().create(2 + cmdLength, 2);
 
             // Set first point from MoveTo command
-            nextCoord = nextCoordSeq.getCoordinate(0);
-            nextCoord.setOrdinate(0, cursor.x);
-            nextCoord.setOrdinate(1, cursor.y);
+            nextCoordSeq.setOrdinate(0, 0, cursor.x);
+            nextCoordSeq.setOrdinate(0, 1, cursor.y);
 
             // Set remaining points from LineTo command
             for(int lineToIndex = 0; lineToIndex < cmdLength; ++lineToIndex) {
@@ -416,9 +410,8 @@ public final class MvtReader {
                         ZigZag.decode(geomCmds.get(i++))
                 );
 
-                nextCoord = nextCoordSeq.getCoordinate(lineToIndex + 1);
-                nextCoord.setOrdinate(0, cursor.x);
-                nextCoord.setOrdinate(1, cursor.y);
+                nextCoordSeq.setOrdinate(lineToIndex + 1, 0, cursor.x);
+                nextCoordSeq.setOrdinate(lineToIndex + 1, 1, cursor.y);
             }
 
 
@@ -436,9 +429,8 @@ public final class MvtReader {
             }
 
             // Set last point from ClosePath command
-            nextCoord = nextCoordSeq.getCoordinate(nextCoordSeq.size() - 1);
-            nextCoord.setOrdinate(0, nextCoordSeq.getOrdinate(0, 0));
-            nextCoord.setOrdinate(1, nextCoordSeq.getOrdinate(0, 1));
+            nextCoordSeq.setOrdinate(nextCoordSeq.size() - 1, 0, nextCoordSeq.getOrdinate(0, 0));
+            nextCoordSeq.setOrdinate(nextCoordSeq.size() - 1, 1, nextCoordSeq.getOrdinate(0, 1));
 
             rings.add(geomFactory.createLinearRing(nextCoordSeq));
         }

--- a/src/main/java/com/wdtinc/mapbox_vector_tile/build/MvtLayerBuild.java
+++ b/src/main/java/com/wdtinc/mapbox_vector_tile/build/MvtLayerBuild.java
@@ -2,7 +2,6 @@ package com.wdtinc.mapbox_vector_tile.build;
 
 import com.wdtinc.mapbox_vector_tile.VectorTile;
 import com.wdtinc.mapbox_vector_tile.encoding.MvtValue;
-import java.util.Iterator;
 
 /**
  * Utility methods for building Mapbox-Vector-Tile layers.

--- a/src/test/java/com/wdtinc/mapbox_vector_tile/adapt/jts/MvtReaderTest.java
+++ b/src/test/java/com/wdtinc/mapbox_vector_tile/adapt/jts/MvtReaderTest.java
@@ -2,7 +2,10 @@ package com.wdtinc.mapbox_vector_tile.adapt.jts;
 
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Polygon;
+
 import com.wdtinc.mapbox_vector_tile.adapt.jts.model.JtsLayer;
 import com.wdtinc.mapbox_vector_tile.adapt.jts.model.JtsMvt;
 import com.wdtinc.mapbox_vector_tile.util.JtsGeomStats;
@@ -22,12 +25,14 @@ import static org.junit.Assert.fail;
  */
 public final class MvtReaderTest {
 
+    private static final double DOUBLE_DELTA = 1e-10;
+    
     @Test
     public void testLayers() {
         try {
             JtsMvt result = MvtReader.loadMvt(
                 new File("src/test/resources/vec_tile_test/game.mvt"),
-                new GeometryFactory(),
+                createGeometryFactory(),
                 new TagKeyValueMapConverter());
 
             final Collection<JtsLayer> layerValues = result.getLayers();
@@ -79,6 +84,36 @@ public final class MvtReaderTest {
 
             assertEquals(1, geoms.size());
             assertTrue(geoms.get(0) instanceof MultiPolygon);
+            final MultiPolygon multiPolygon = (MultiPolygon) geoms.get(0);
+            assertEquals(2, multiPolygon.getNumGeometries());
+            {
+                final Polygon polygon = (Polygon) multiPolygon.getGeometryN(0);
+                assertEquals(0, polygon.getNumInteriorRing());
+                final LineString exteriorRing = polygon.getExteriorRing();
+                assertEquals(4, exteriorRing.getNumPoints());
+                assertEquals(2059.0, exteriorRing.getCoordinateN(0).x, DOUBLE_DELTA);
+                assertEquals(2048.0, exteriorRing.getCoordinateN(0).y, DOUBLE_DELTA);
+                assertEquals(2048.0, exteriorRing.getCoordinateN(1).x, DOUBLE_DELTA);
+                assertEquals(2048.0, exteriorRing.getCoordinateN(1).y, DOUBLE_DELTA);
+                assertEquals(2059.0, exteriorRing.getCoordinateN(2).x, DOUBLE_DELTA);
+                assertEquals(2037.0, exteriorRing.getCoordinateN(2).y, DOUBLE_DELTA);
+                assertEquals(2059.0, exteriorRing.getCoordinateN(3).x, DOUBLE_DELTA);
+                assertEquals(2048.0, exteriorRing.getCoordinateN(3).y, DOUBLE_DELTA);
+            }
+            {
+                final Polygon polygon = (Polygon) multiPolygon.getGeometryN(1);
+                assertEquals(0, polygon.getNumInteriorRing());
+                final LineString exteriorRing = polygon.getExteriorRing();
+                assertEquals(4, exteriorRing.getNumPoints());
+                assertEquals(2037.0, exteriorRing.getCoordinateN(0).x, DOUBLE_DELTA);
+                assertEquals(2059.0, exteriorRing.getCoordinateN(0).y, DOUBLE_DELTA);
+                assertEquals(2037.0, exteriorRing.getCoordinateN(1).x, DOUBLE_DELTA);
+                assertEquals(2048.0, exteriorRing.getCoordinateN(1).y, DOUBLE_DELTA);
+                assertEquals(2048.0, exteriorRing.getCoordinateN(2).x, DOUBLE_DELTA);
+                assertEquals(2048.0, exteriorRing.getCoordinateN(2).y, DOUBLE_DELTA);
+                assertEquals(2037.0, exteriorRing.getCoordinateN(3).x, DOUBLE_DELTA);
+                assertEquals(2059.0, exteriorRing.getCoordinateN(3).y, DOUBLE_DELTA);
+            }
         } catch (IOException e) {
             fail(e.getMessage());
         }
@@ -95,7 +130,7 @@ public final class MvtReaderTest {
     private static JtsMvt loadMvt(String file) throws IOException {
         return MvtReader.loadMvt(
                 new File(file),
-                new GeometryFactory(),
+                createGeometryFactory(),
                 new TagKeyValueMapConverter());
     }
 
@@ -103,8 +138,12 @@ public final class MvtReaderTest {
                                   MvtReader.RingClassifier ringClassifier) throws IOException {
         return MvtReader.loadMvt(
                 new File(file),
-                new GeometryFactory(),
+                createGeometryFactory(),
                 new TagKeyValueMapConverter(),
                 ringClassifier);
+    }
+    
+    private static GeometryFactory createGeometryFactory() {
+        return new GeometryFactory();
     }
 }

--- a/src/test/java/com/wdtinc/mapbox_vector_tile/adapt/jts/MvtReaderTest.java
+++ b/src/test/java/com/wdtinc/mapbox_vector_tile/adapt/jts/MvtReaderTest.java
@@ -5,6 +5,8 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
 
 import com.wdtinc.mapbox_vector_tile.adapt.jts.model.JtsLayer;
 import com.wdtinc.mapbox_vector_tile.adapt.jts.model.JtsMvt;
@@ -26,6 +28,9 @@ import static org.junit.Assert.fail;
 public final class MvtReaderTest {
 
     private static final double DOUBLE_DELTA = 1e-10;
+    
+    private static final int NUMBER_OF_DIMENSIONS = 2;
+    private static final int SRID = 0;
     
     @Test
     public void testLayers() {
@@ -144,6 +149,9 @@ public final class MvtReaderTest {
     }
     
     private static GeometryFactory createGeometryFactory() {
-        return new GeometryFactory();
+        final PrecisionModel precisionModel = new PrecisionModel();
+        final PackedCoordinateSequenceFactory coordinateSequenceFactory = 
+                new PackedCoordinateSequenceFactory(PackedCoordinateSequenceFactory.DOUBLE, NUMBER_OF_DIMENSIONS);
+        return new GeometryFactory(precisionModel, SRID, coordinateSequenceFactory);
     }
 }


### PR DESCRIPTION
Currently MvtReader fails when a GeometryFactory is used that creates PackedCoordinateSequence's. This pull request fixes that.