### PR TITLE
upgrade to jts 1.16.0 and protobuf-java 3.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 install: true
 script: mvn clean test
 cache:

--- a/pom.xml
+++ b/pom.xml
@@ -152,14 +152,14 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.5.1</version>
+            <version>3.6.1</version>
         </dependency>
 
         <!-- Geometry model -->
         <dependency>
             <groupId>org.locationtech.jts</groupId>
             <artifactId>jts-core</artifactId>
-            <version>1.15.1</version>
+            <version>1.16.0</version>
         </dependency>
 
         <!-- Testing -->

--- a/src/test/java/com/wdtinc/mapbox_vector_tile/adapt/jts/MvtReaderTest.java
+++ b/src/test/java/com/wdtinc/mapbox_vector_tile/adapt/jts/MvtReaderTest.java
@@ -28,10 +28,9 @@ import static org.junit.Assert.fail;
 public final class MvtReaderTest {
 
     private static final double DOUBLE_DELTA = 1e-10;
-    
-    private static final int NUMBER_OF_DIMENSIONS = 2;
+
     private static final int SRID = 0;
-    
+
     @Test
     public void testLayers() {
         try {
@@ -147,11 +146,10 @@ public final class MvtReaderTest {
                 new TagKeyValueMapConverter(),
                 ringClassifier);
     }
-    
+
     private static GeometryFactory createGeometryFactory() {
         final PrecisionModel precisionModel = new PrecisionModel();
-        final PackedCoordinateSequenceFactory coordinateSequenceFactory = 
-                new PackedCoordinateSequenceFactory(PackedCoordinateSequenceFactory.DOUBLE, NUMBER_OF_DIMENSIONS);
+        final PackedCoordinateSequenceFactory coordinateSequenceFactory = new PackedCoordinateSequenceFactory();
         return new GeometryFactory(precisionModel, SRID, coordinateSequenceFactory);
     }
 }


### PR DESCRIPTION
We use your library successfully here: https://github.com/graphhopper/graphhopper/pull/1572 Thanks!

Now we need to upgrade to the latest JTS 0.16.0, because JTS 0.15.1 and 0.16.0 are slightly different for certain method signatures and we can only upgrade if we upgrade all our dependencies that use it :)

Additionally protobuf-java has a new release 3.6.1 ([from 31 Jul 2018](https://github.com/protocolbuffers/protobuf/releases/tag/v3.6.1)) which is e.g. used from [osm binary](https://github.com/openstreetmap/osmosis/tree/master/osmosis-osm-binary). But we can also keep it at 3.5.1