### PR TITLE
Fix version number from 3.1.1 to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Latest version using JTS 15 with android API level 15 support:
 <dependency>
     <groupId>com.wdtinc</groupId>
     <artifactId>mapbox-vector-tile</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.0</version>
 </dependency>
 ```
 
@@ -60,7 +60,7 @@ JTS 14 with no android support:
 Latest version using JTS 15 with android API level 15 support:
 
 ```
-compile 'com.wdtinc:mapbox-vector-tile:3.1.1'
+compile 'com.wdtinc:mapbox-vector-tile:3.1.0'
 ```
 
 JTS 14 with no android support:


### PR DESCRIPTION
There are two typos under the Dependency section in README file with version numbers.
The latest release is 3.1.0, but README says 3.1.1