### PR TITLE
Avoid ArrayIndexOutOfBoundsException on coordSeq when there are extra commands than specified in header

### DIFF
--- a/src/main/java/com/wdtinc/mapbox_vector_tile/adapt/jts/MvtReader.java
+++ b/src/main/java/com/wdtinc/mapbox_vector_tile/adapt/jts/MvtReader.java
@@ -211,8 +211,12 @@ public final class MvtReader {
 
         // Guard: header data unsupported by geometry command buffer
         //  (require header and at least 1 value * 2 params)
-        if(cmdLength * GeomCmd.MoveTo.getParamCount() + 1 > geomCmds.size()) {
+        int requiredgeomCmdsLength = cmdLength * GeomCmd.MoveTo.getParamCount() + 1;
+        if(requiredgeomCmdsLength > geomCmds.size()) {
             return null;
+        }
+        if (requiredgeomCmdsLength < geomCmds.size()) {
+            geomCmds = geomCmds.subList(0, requiredgeomCmdsLength); // ignore extra commands... should it return null instead?
         }
 
         final CoordinateSequence coordSeq = geomFactory.getCoordinateSequenceFactory().create(cmdLength, 2);


### PR DESCRIPTION
This fixes https://github.com/wdtinc/mapbox-vector-tile-java/issues/51

Although it is ignoring the extra commands it will probably load wrong data. Maybe it should return null?